### PR TITLE
Pass the processed CheckResult map to next StreamStage

### DIFF
--- a/resources/riemann_config.clj
+++ b/resources/riemann_config.clj
@@ -1,24 +1,15 @@
 (require '[riemann.streams :refer :all]
          '[riemann.core :as core])
 
-(defn to-event [result response]
-  (assoc response
-    :host (get-in response [:target :id])
-    :service (:check_id result)
-    :time (:timestamp result)))
-
-(defn parse-stream [& children]
-  (fn [result]
-    (let [event (assoc result :responses (map #(to-event result %) (:responses result)))]
-
-      (call-rescue (to-event result event) children))))
-
 (defn is-opsee-event [& children]
   (fn [event] (if (not (nil? (:customer_id event))) (call-rescue event children) nil)))
 
 (let [index (core/wrap-index (index))]
+  ;; This stream must be, in total, synchronous. Any asynchronous operations
+  ;; must happen in another stream. This stream only updates the in-memory
+  ;; state so that after a call to stream!, we can immediately query the
+  ;; index to get the state of the mutated event.
   (streams
     (is-opsee-event
-      (parse-stream
-        (by [:customer_id :check_id]
-            (fn [event] (index event)))))))
+      (by [:customer_id :check_id]
+          (fn [event] (index event))))))

--- a/test/beavis/t_habilitationsschrift.clj
+++ b/test/beavis/t_habilitationsschrift.clj
@@ -8,35 +8,54 @@
             [riemann.logging :as logging]
             [clojure.tools.logging :as log])
   (:import (co.opsee.proto CheckResult CheckResponse Target Timestamp Any HttpResponse)
-           (beavis.stream StreamStage)))
+           (beavis.stream StreamStage)
+           (clojure.lang PersistentArrayMap)))
 
-(defn next-callback [_] nil)
+(def received-event (atom false))
+(def core-stream (atom nil))
+
+(defn next-callback [event]
+  (reset! received-event true)
+  event)
 (set-format "Timestamp" "int64")
 
 (logging/suppress
   ["riemann.core" "riemann.pubsub"]
   (facts
     "core services are started"
-    (against-background
-      [(around :facts
-               (let [core-stream (hab/CoreStreamer 1)]
-                 (s/start-stage! core-stream)
-                 ?form
-                 (s/stop-stage! core-stream)))]
+    (with-state-changes
+      [(before :facts (do
+                        (reset! core-stream (hab/CoreStreamer 1))
+                        (s/start-stage! @core-stream)))
+       (after :facts (do
+                       (s/stop-stage! @core-stream)
+                       (reset! core-stream nil)
+                       (reset! received-event false)))]
       (fact "pubsub service is started"
             (:pubsub @core) =not=> nil?)))
+
   (facts
-    "configuration works as expected"
-    (let [result-map (proto->hash (check-result 3 3 0))]
-      (against-background
-        [(around :facts
-                 (let [core-stream (hab/CoreStreamer 1)]
-                   (s/start-stage! core-stream)
-                   ?form
-                   (s/stop-stage! core-stream)))]
+    "configuration generally works"
+    (with-state-changes
+      [(before :facts (do
+                        (reset! core-stream (hab/CoreStreamer 1))
+                        (s/start-stage! @core-stream)))
+       (after :facts (do
+                       (s/stop-stage! @core-stream)
+                       (reset! core-stream nil)
+                       (reset! received-event false)))]
+      (let [result-map (proto->hash (check-result 3 3 0))]
         (fact "an index is created"
               (:index @core) =not=> nil?)
         (fact "submitting an event adds it to the index"
-              (s/submit core-stream result-map next-callback)
-              (Thread/sleep 1000)
-              (count (.seq (:index @core))) => 1)))))
+              (s/submit @core-stream result-map next-callback)
+              (count (.seq (:index @core))) => 1)
+        (fact "submitting an event sends it to the next step"
+              (s/submit @core-stream result-map next-callback)
+              @received-event => true)
+        (fact "submit returns the correct event"
+              (let [events (map #(proto->hash (check-result 3 3 %)) (range 1 4))]
+                (map #(s/submit @core-stream % next-callback) events)
+                (let [r (s/submit @core-stream result-map next-callback)]
+                  (type r) => PersistentArrayMap
+                  (:time r) => (:timestamp result-map))))))))


### PR DESCRIPTION
After submitting an event to the core synchronously, the event
is persisted in the index and immediately sent on to the next
stream stage.
